### PR TITLE
fix: Granting a permission set to multiple accounts gives an error

### DIFF
--- a/API.md
+++ b/API.md
@@ -278,26 +278,20 @@ account for data recovery and cleanup later (`RemovalPolicy.RETAIN`).
 ##### `grant` <a name="grant" id="@renovosolutions/cdk-library-aws-sso.PermissionSet.grant"></a>
 
 ```typescript
-public grant(principal: PrincipalProperty, targetId: string, targetType?: TargetTypes): Assignment
+public grant(id: string, assignmentOptions: AssignmentOptions): Assignment
 ```
 
 Grant this permission set to a given principal for a given targetId (AWS account identifier) on a given SSO instance.
 
-###### `principal`<sup>Required</sup> <a name="principal" id="@renovosolutions/cdk-library-aws-sso.PermissionSet.grant.parameter.principal"></a>
-
-- *Type:* <a href="#@renovosolutions/cdk-library-aws-sso.PrincipalProperty">PrincipalProperty</a>
-
----
-
-###### `targetId`<sup>Required</sup> <a name="targetId" id="@renovosolutions/cdk-library-aws-sso.PermissionSet.grant.parameter.targetId"></a>
+###### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-aws-sso.PermissionSet.grant.parameter.id"></a>
 
 - *Type:* string
 
 ---
 
-###### `targetType`<sup>Optional</sup> <a name="targetType" id="@renovosolutions/cdk-library-aws-sso.PermissionSet.grant.parameter.targetType"></a>
+###### `assignmentOptions`<sup>Required</sup> <a name="assignmentOptions" id="@renovosolutions/cdk-library-aws-sso.PermissionSet.grant.parameter.assignmentOptions"></a>
 
-- *Type:* <a href="#@renovosolutions/cdk-library-aws-sso.TargetTypes">TargetTypes</a>
+- *Type:* <a href="#@renovosolutions/cdk-library-aws-sso.AssignmentOptions">AssignmentOptions</a>
 
 ---
 
@@ -498,6 +492,65 @@ const assignmentAttributes: AssignmentAttributes = { ... }
 ```
 
 
+### AssignmentOptions <a name="AssignmentOptions" id="@renovosolutions/cdk-library-aws-sso.AssignmentOptions"></a>
+
+The options for creating an assignment.
+
+#### Initializer <a name="Initializer" id="@renovosolutions/cdk-library-aws-sso.AssignmentOptions.Initializer"></a>
+
+```typescript
+import { AssignmentOptions } from '@renovosolutions/cdk-library-aws-sso'
+
+const assignmentOptions: AssignmentOptions = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-aws-sso.AssignmentOptions.property.principal">principal</a></code> | <code><a href="#@renovosolutions/cdk-library-aws-sso.PrincipalProperty">PrincipalProperty</a></code> | The principal to assign the permission set to. |
+| <code><a href="#@renovosolutions/cdk-library-aws-sso.AssignmentOptions.property.targetId">targetId</a></code> | <code>string</code> | The target id the permission set will be assigned to. |
+| <code><a href="#@renovosolutions/cdk-library-aws-sso.AssignmentOptions.property.targetType">targetType</a></code> | <code><a href="#@renovosolutions/cdk-library-aws-sso.TargetTypes">TargetTypes</a></code> | The entity type for which the assignment will be created. |
+
+---
+
+##### `principal`<sup>Required</sup> <a name="principal" id="@renovosolutions/cdk-library-aws-sso.AssignmentOptions.property.principal"></a>
+
+```typescript
+public readonly principal: PrincipalProperty;
+```
+
+- *Type:* <a href="#@renovosolutions/cdk-library-aws-sso.PrincipalProperty">PrincipalProperty</a>
+
+The principal to assign the permission set to.
+
+---
+
+##### `targetId`<sup>Required</sup> <a name="targetId" id="@renovosolutions/cdk-library-aws-sso.AssignmentOptions.property.targetId"></a>
+
+```typescript
+public readonly targetId: string;
+```
+
+- *Type:* string
+
+The target id the permission set will be assigned to.
+
+---
+
+##### `targetType`<sup>Optional</sup> <a name="targetType" id="@renovosolutions/cdk-library-aws-sso.AssignmentOptions.property.targetType"></a>
+
+```typescript
+public readonly targetType: TargetTypes;
+```
+
+- *Type:* <a href="#@renovosolutions/cdk-library-aws-sso.TargetTypes">TargetTypes</a>
+- *Default:* TargetTypes.AWS_ACCOUNT
+
+The entity type for which the assignment will be created.
+
+---
+
 ### AssignmentProps <a name="AssignmentProps" id="@renovosolutions/cdk-library-aws-sso.AssignmentProps"></a>
 
 The properties of a new assignment.
@@ -514,22 +567,10 @@ const assignmentProps: AssignmentProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#@renovosolutions/cdk-library-aws-sso.AssignmentProps.property.permissionSet">permissionSet</a></code> | <code><a href="#@renovosolutions/cdk-library-aws-sso.IPermissionSet">IPermissionSet</a></code> | The permission set to assign to the principal. |
 | <code><a href="#@renovosolutions/cdk-library-aws-sso.AssignmentProps.property.principal">principal</a></code> | <code><a href="#@renovosolutions/cdk-library-aws-sso.PrincipalProperty">PrincipalProperty</a></code> | The principal to assign the permission set to. |
 | <code><a href="#@renovosolutions/cdk-library-aws-sso.AssignmentProps.property.targetId">targetId</a></code> | <code>string</code> | The target id the permission set will be assigned to. |
 | <code><a href="#@renovosolutions/cdk-library-aws-sso.AssignmentProps.property.targetType">targetType</a></code> | <code><a href="#@renovosolutions/cdk-library-aws-sso.TargetTypes">TargetTypes</a></code> | The entity type for which the assignment will be created. |
-
----
-
-##### `permissionSet`<sup>Required</sup> <a name="permissionSet" id="@renovosolutions/cdk-library-aws-sso.AssignmentProps.property.permissionSet"></a>
-
-```typescript
-public readonly permissionSet: IPermissionSet;
-```
-
-- *Type:* <a href="#@renovosolutions/cdk-library-aws-sso.IPermissionSet">IPermissionSet</a>
-
-The permission set to assign to the principal.
+| <code><a href="#@renovosolutions/cdk-library-aws-sso.AssignmentProps.property.permissionSet">permissionSet</a></code> | <code><a href="#@renovosolutions/cdk-library-aws-sso.IPermissionSet">IPermissionSet</a></code> | The permission set to assign to the principal. |
 
 ---
 
@@ -567,6 +608,18 @@ public readonly targetType: TargetTypes;
 - *Default:* TargetTypes.AWS_ACCOUNT
 
 The entity type for which the assignment will be created.
+
+---
+
+##### `permissionSet`<sup>Required</sup> <a name="permissionSet" id="@renovosolutions/cdk-library-aws-sso.AssignmentProps.property.permissionSet"></a>
+
+```typescript
+public readonly permissionSet: IPermissionSet;
+```
+
+- *Type:* <a href="#@renovosolutions/cdk-library-aws-sso.IPermissionSet">IPermissionSet</a>
+
+The permission set to assign to the principal.
 
 ---
 
@@ -1010,26 +1063,20 @@ The resource interface for an AWS SSO permission set.
 ##### `grant` <a name="grant" id="@renovosolutions/cdk-library-aws-sso.IPermissionSet.grant"></a>
 
 ```typescript
-public grant(principal: PrincipalProperty, targetId: string, targetType?: TargetTypes): Assignment
+public grant(id: string, assignmentOptions: AssignmentOptions): Assignment
 ```
 
 Grant this permission set to a given principal for a given targetId (AWS account identifier) on a given SSO instance.
 
-###### `principal`<sup>Required</sup> <a name="principal" id="@renovosolutions/cdk-library-aws-sso.IPermissionSet.grant.parameter.principal"></a>
-
-- *Type:* <a href="#@renovosolutions/cdk-library-aws-sso.PrincipalProperty">PrincipalProperty</a>
-
----
-
-###### `targetId`<sup>Required</sup> <a name="targetId" id="@renovosolutions/cdk-library-aws-sso.IPermissionSet.grant.parameter.targetId"></a>
+###### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-aws-sso.IPermissionSet.grant.parameter.id"></a>
 
 - *Type:* string
 
 ---
 
-###### `targetType`<sup>Optional</sup> <a name="targetType" id="@renovosolutions/cdk-library-aws-sso.IPermissionSet.grant.parameter.targetType"></a>
+###### `assignmentOptions`<sup>Required</sup> <a name="assignmentOptions" id="@renovosolutions/cdk-library-aws-sso.IPermissionSet.grant.parameter.assignmentOptions"></a>
 
-- *Type:* <a href="#@renovosolutions/cdk-library-aws-sso.TargetTypes">TargetTypes</a>
+- *Type:* <a href="#@renovosolutions/cdk-library-aws-sso.AssignmentOptions">AssignmentOptions</a>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ new Assignment(this, 'ExampleAssignment', {
 });
 
 // assign it to something else with a grant
-permissionSetExample.grant(
-  {
+permissionSetExample.grant('permissionSetExampleAssignment',
+  principal: {
     principalId: '12350630-0ae9-479a-97c2-0afc2d5b4eac',
     principalType: PrincipalTypes.GROUP,
   },
-  '344567890123456',
+  targetId: '344567890123456',
 );
 
 // import an existing permission set

--- a/src/assignment.ts
+++ b/src/assignment.ts
@@ -35,30 +35,35 @@ abstract class AssignmentBase extends Resource implements IAssignment {};
 export interface AssignmentAttributes {}
 
 /**
+ * The options for creating an assignment.
+ */
+export interface AssignmentOptions {
+  /**
+  * The principal to assign the permission set to
+  */
+  readonly principal: PrincipalProperty;
+
+  /**
+  * The target id the permission set will be assigned to
+  */
+  readonly targetId: string;
+
+  /**
+  * The entity type for which the assignment will be created.
+  *
+  * @default TargetTypes.AWS_ACCOUNT
+  */
+  readonly targetType?: TargetTypes;
+}
+
+/**
  * The properties of a new assignment.
  */
-export interface AssignmentProps {
+export interface AssignmentProps extends AssignmentOptions {
   /**
    * The permission set to assign to the principal
    */
   readonly permissionSet: IPermissionSet;
-
-  /**
-   * The principal to assign the permission set to
-   */
-  readonly principal: PrincipalProperty;
-
-  /**
-   * The target id the permission set will be assigned to
-   */
-  readonly targetId: string;
-
-  /**
-   * The entity type for which the assignment will be created.
-   *
-   * @default TargetTypes.AWS_ACCOUNT
-   */
-  readonly targetType?: TargetTypes;
 }
 
 /**

--- a/src/permissionset.ts
+++ b/src/permissionset.ts
@@ -6,8 +6,7 @@ import {
   Duration,
 } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import { Assignment, TargetTypes } from './assignment';
-import { PrincipalProperty } from './principal';
+import { Assignment, AssignmentOptions } from './assignment';
 import { permissionSetParseArn } from './private/permissionset-common';
 
 export interface CustomerManagedPolicyReference extends sso.CfnPermissionSet.CustomerManagedPolicyReferenceProperty {}
@@ -34,7 +33,7 @@ export interface IPermissionSet extends IResource {
    * Grant this permission set to a given principal for a given
    * targetId (AWS account identifier) on a given SSO instance.
    */
-  grant(principal: PrincipalProperty, targetId: string, targetType?: TargetTypes): Assignment;
+  grant(id: string, assignmentOptions: AssignmentOptions): Assignment;
 }
 
 /**
@@ -44,12 +43,12 @@ abstract class PermissionSetBase extends Resource implements IPermissionSet {
   public abstract readonly permissionSetArn: string;
   public abstract readonly ssoInstanceArn: string;
 
-  public grant(principal: PrincipalProperty, targetId: string, targetType: TargetTypes = TargetTypes.AWS_ACCOUNT): Assignment {
-    return new Assignment(this, 'Assignment', {
+  public grant(id: string, assignmentOptions: AssignmentOptions): Assignment {
+    return new Assignment(this, id, {
       permissionSet: this,
-      principal: principal,
-      targetId,
-      targetType,
+      principal: assignmentOptions.principal,
+      targetId: assignmentOptions.targetId,
+      targetType: assignmentOptions.targetType,
     });
   }
 };

--- a/test/__snapshots__/createAndGrantPermSnapshot.test.ts.snap
+++ b/test/__snapshots__/createAndGrantPermSnapshot.test.ts.snap
@@ -10,7 +10,7 @@ Object {
     },
   },
   "Resources": Object {
-    "PermissionSetAssignmentassignment0A69C6D0": Object {
+    "PermissionSetpermissionSetAssignmentassignmentBF53D72E": Object {
       "Properties": Object {
         "InstanceArn": "arn:aws:sso:::instance/ssoins-1234567891234567",
         "PermissionSetArn": Object {
@@ -19,9 +19,9 @@ Object {
             "PermissionSetArn",
           ],
         },
-        "PrincipalId": "25750630-0ae9-479a-97c2-0afc2d5b4eac",
+        "PrincipalId": "12350630-0ae9-479a-97c2-0afc2d5b4eac",
         "PrincipalType": "GROUP",
-        "TargetId": "124567890123456",
+        "TargetId": "344567890123456",
         "TargetType": "AWS_ACCOUNT",
       },
       "Type": "AWS::SSO::Assignment",

--- a/test/__snapshots__/importAndGrantPermSnapshot.test.ts.snap
+++ b/test/__snapshots__/importAndGrantPermSnapshot.test.ts.snap
@@ -10,13 +10,13 @@ Object {
     },
   },
   "Resources": Object {
-    "PermissionSetAssignmentassignment0A69C6D0": Object {
+    "PermissionSetpermissionSetAssignmentassignmentBF53D72E": Object {
       "Properties": Object {
         "InstanceArn": "arn:aws:sso:::instance/ssoins-1234567891234567",
         "PermissionSetArn": "arn:aws:sso:::permissionSet/ssoins-1234567891234567/ps-55a5555a5a55ab55",
-        "PrincipalId": "25750630-0ae9-479a-97c2-0afc2d5b4eac",
+        "PrincipalId": "12350630-0ae9-479a-97c2-0afc2d5b4eac",
         "PrincipalType": "GROUP",
-        "TargetId": "124567890123456",
+        "TargetId": "344567890123456",
         "TargetType": "AWS_ACCOUNT",
       },
       "Type": "AWS::SSO::Assignment",

--- a/test/createAndGrantPermSnapshot.test.ts
+++ b/test/createAndGrantPermSnapshot.test.ts
@@ -42,13 +42,13 @@ test('Snapshot', () => {
     },
   });
 
-  permissionSet.grant(
-    {
-      principalId: '25750630-0ae9-479a-97c2-0afc2d5b4eac',
+  permissionSet.grant('permissionSetAssignment', {
+    principal: {
+      principalId: '12350630-0ae9-479a-97c2-0afc2d5b4eac',
       principalType: PrincipalTypes.GROUP,
     },
-    '124567890123456',
-  );
+    targetId: '344567890123456',
+  });
 
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });

--- a/test/importAndGrantPermSnapshot.test.ts
+++ b/test/importAndGrantPermSnapshot.test.ts
@@ -14,13 +14,13 @@ test('Snapshot', () => {
 
   const permissionSet = PermissionSet.fromPermissionSetArn(stack, 'PermissionSet', 'arn:aws:sso:::permissionSet/ssoins-1234567891234567/ps-55a5555a5a55ab55');
 
-  permissionSet.grant(
-    {
-      principalId: '25750630-0ae9-479a-97c2-0afc2d5b4eac',
+  permissionSet.grant('permissionSetAssignment', {
+    principal: {
+      principalId: '12350630-0ae9-479a-97c2-0afc2d5b4eac',
       principalType: PrincipalTypes.GROUP,
     },
-    '124567890123456',
-  );
+    targetId: '344567890123456',
+  });
 
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -33,13 +33,13 @@ test('PermissionSetImportGrantsWithoutError', () => {
   const permissionSet = PermissionSet.fromPermissionSetArn(stack, 'PermissionSet', 'arn:aws:sso:::permissionSet/ssoins-1234567891234567/ps-55a5555a5a55ab55');
 
   expect(() => {
-    permissionSet.grant(
-      {
-        principalId: '25750630-0ae9-479a-97c2-0afc2d5b4eac',
+    permissionSet.grant('permissionSetAssignment', {
+      principal: {
+        principalId: '12350630-0ae9-479a-97c2-0afc2d5b4eac',
         principalType: PrincipalTypes.GROUP,
       },
-      '124567890123456',
-    );
+      targetId: '344567890123456',
+    });
   }).not.toThrow();
 });
 
@@ -50,32 +50,57 @@ test('PermissionSetImportGrantErrorsWithNonGUIDPrincipalId', () => {
   const permissionSet = PermissionSet.fromPermissionSetArn(stack, 'PermissionSet', 'arn:aws:sso:::permissionSet/ssoins-1234567891234567/ps-55a5555a5a55ab55');
 
   expect(() => {
-    permissionSet.grant(
-      {
+    permissionSet.grant('permissionSetAssignment', {
+      principal: {
         principalId: 'bad-principal-id',
         principalType: PrincipalTypes.GROUP,
       },
-      '124567890123456',
-    );
+      targetId: '344567890123456',
+    });
   }).toThrow(/PrincipalId must be a valid GUID: bad-principal-id/);
 });
 
-test('PermissionSetImportGrantErrorsWithNonValidTargetId', () => {
+test('PermissionSetGrantedToMultipleAccountsDoesNotError', () => {
   const app = new App();
   const stack = new Stack(app, 'TestStack');
 
   const permissionSet = PermissionSet.fromPermissionSetArn(stack, 'PermissionSet', 'arn:aws:sso:::permissionSet/ssoins-1234567891234567/ps-55a5555a5a55ab55');
 
+  permissionSet.grant('permissionSetAssignment1', {
+    principal: {
+      principalId: '12350630-0ae9-479a-97c2-0afc2d5b4eac',
+      principalType: PrincipalTypes.GROUP,
+    },
+    targetId: '123567890123456',
+  });
+
   expect(() => {
-    permissionSet.grant(
-      {
-        principalId: '25750630-0ae9-479a-97c2-0afc2d5b4eac',
+    permissionSet.grant('permissionSetAssignment2', {
+      principal: {
+        principalId: '12350630-0ae9-479a-97c2-0afc2d5b4eac',
         principalType: PrincipalTypes.GROUP,
       },
-      '123',
-    );
-  }).toThrow(/targetId should be a 12 digit AWS account id: 123/);
+      targetId: '344567890123456',
+    });
+  }).not.toThrow();
 });
+
+// test('PermissionSetImportGrantErrorsWithNonValidTargetId', () => {
+//   const app = new App();
+//   const stack = new Stack(app, 'TestStack');
+
+//   const permissionSet = PermissionSet.fromPermissionSetArn(stack, 'PermissionSet', 'arn:aws:sso:::permissionSet/ssoins-1234567891234567/ps-55a5555a5a55ab55');
+
+//   expect(() => {
+//     permissionSet.grant('permissionSetAssignment', {
+//       principal: {
+//         principalId: '12350630-0ae9-479a-97c2-0afc2d5b4eac',
+//         principalType: PrincipalTypes.GROUP,
+//       },
+//       targetId: '123',
+//     });
+//   }).toThrow(/targetId should be a 12 digit AWS account id: 123/);
+// });
 
 test('PermissionSetCreationSucceedsWithRequiredPropsOnly', () => {
   const app = new App();


### PR DESCRIPTION
BREAKING CHANGE: `Error: There is already a Construct with name 'Assignment'` is generated when granting more then once. Or really having more then a single `grant` at all. This occurred because the `grant` was not set up correctly. This PR refactors the grant entirely.