### PR TITLE
chore: update project repo link

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -7,7 +7,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   defaultReleaseBranch: 'main',
   name: '@renovosolutions/cdk-library-aws-sso',
   description: 'AWS CDK Construct Library for AWS SSO',
-  repositoryUrl: 'https://github.com/brandon/cdk-library-aws-sso.git',
+  repositoryUrl: 'https://github.com/RenovoSolutions/cdk-library-aws-sso.git',
   keywords: [
     'cdk',
     'aws-cdk',

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "AWS CDK Construct Library for AWS SSO",
   "repository": {
     "type": "git",
-    "url": "https://github.com/brandon/cdk-library-aws-sso.git"
+    "url": "https://github.com/RenovoSolutions/cdk-library-aws-sso.git"
   },
   "scripts": {
     "build": "npx projen build",


### PR DESCRIPTION
The current repo link on npm 404's


_please note that the github UI added that trailing newline, let me know if you want it scrubbed.