### PR TITLE
wip: failing test for Fn.ImportValue

### DIFF
--- a/test/createAndGrantPermSnapshot.test.ts
+++ b/test/createAndGrantPermSnapshot.test.ts
@@ -3,6 +3,7 @@ import {
   App,
   aws_iam as iam,
   Duration,
+  Fn,
 } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import {
@@ -21,6 +22,49 @@ test('Snapshot', () => {
     description: 'Test Permission Set',
     name: 'TestPermissionSet',
     ssoInstanceArn: 'arn:aws:sso:::instance/ssoins-1234567891234567',
+    relayStateType: 'https://us-east-1.console.aws.amazon.com/rds/home',
+    sessionDuration: Duration.hours(10),
+    customerManagedPolicyReferences: [
+      {
+        name: 'TestPolicy',
+        path: '/',
+      },
+    ],
+    inlinePolicy: new iam.PolicyDocument({
+      statements: [
+        new iam.PolicyStatement({
+          actions: ['rds:*'],
+          resources: ['*'],
+        }),
+      ],
+    }),
+    permissionsBoundary: {
+      managedPolicyArn: iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonRDSPerformanceInsightsReadOnly').managedPolicyArn,
+    },
+  });
+
+  permissionSet.grant('permissionSetAssignment', {
+    principal: {
+      principalId: '12350630-0ae9-479a-97c2-0afc2d5b4eac',
+      principalType: PrincipalTypes.GROUP,
+    },
+    targetId: '344567890123456',
+  });
+
+  expect(Template.fromStack(stack)).toMatchSnapshot();
+});
+
+test('Snapshot importValue', () => {
+  const app = new App();
+  const stack = new Stack(app, 'TestStack');
+
+  const permissionSet = new PermissionSet(stack, 'PermissionSet', {
+    awsManagedPolicies: [
+      iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonRDSPerformanceInsightsReadOnly'),
+    ],
+    description: 'Test Permission Set',
+    name: 'TestPermissionSet',
+    ssoInstanceArn: Fn.importValue('fake-sso-instance-arn'),
     relayStateType: 'https://us-east-1.console.aws.amazon.com/rds/home',
     sessionDuration: Duration.hours(10),
     customerManagedPolicyReferences: [

--- a/test/createAndGrantPermSnapshot.test.ts
+++ b/test/createAndGrantPermSnapshot.test.ts
@@ -21,50 +21,7 @@ test('Snapshot', () => {
     ],
     description: 'Test Permission Set',
     name: 'TestPermissionSet',
-    ssoInstanceArn: 'arn:aws:sso:::instance/ssoins-1234567891234567',
-    relayStateType: 'https://us-east-1.console.aws.amazon.com/rds/home',
-    sessionDuration: Duration.hours(10),
-    customerManagedPolicyReferences: [
-      {
-        name: 'TestPolicy',
-        path: '/',
-      },
-    ],
-    inlinePolicy: new iam.PolicyDocument({
-      statements: [
-        new iam.PolicyStatement({
-          actions: ['rds:*'],
-          resources: ['*'],
-        }),
-      ],
-    }),
-    permissionsBoundary: {
-      managedPolicyArn: iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonRDSPerformanceInsightsReadOnly').managedPolicyArn,
-    },
-  });
-
-  permissionSet.grant('permissionSetAssignment', {
-    principal: {
-      principalId: '12350630-0ae9-479a-97c2-0afc2d5b4eac',
-      principalType: PrincipalTypes.GROUP,
-    },
-    targetId: '344567890123456',
-  });
-
-  expect(Template.fromStack(stack)).toMatchSnapshot();
-});
-
-test('Snapshot importValue', () => {
-  const app = new App();
-  const stack = new Stack(app, 'TestStack');
-
-  const permissionSet = new PermissionSet(stack, 'PermissionSet', {
-    awsManagedPolicies: [
-      iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonRDSPerformanceInsightsReadOnly'),
-    ],
-    description: 'Test Permission Set',
-    name: 'TestPermissionSet',
-    ssoInstanceArn: Fn.importValue('fake-sso-instance-arn'),
+    ssoInstanceArn: Fn.importValue('path.to.ssoInstanceArn.in.buildConfig'),
     relayStateType: 'https://us-east-1.console.aws.amazon.com/rds/home',
     sessionDuration: Duration.hours(10),
     customerManagedPolicyReferences: [


### PR DESCRIPTION
Unit test to demonstrate an issue with Fn.ImportValue. In the cdk projects I work on, we store all hardcoded strings in yml files and import them at deployment time using Fn.ImportValue. This fails the ARN validator logic. I don't know the best solution to fix the issue.

The error message is:
```
    Invalid SSO instance ARN: ${Token[TOKEN.665]}

      189 |
      190 |     if (!props.ssoInstanceArn.match(/arn:(aws|aws-us-gov|aws-cn|aws-iso|aws-iso-b):sso:::instance\/(sso)?ins-[a-zA-Z0-9-.]{16}/)) {
    > 191 |       throw new Error(`Invalid SSO instance ARN: ${props.ssoInstanceArn}`);
```